### PR TITLE
feat(pwa): auto-reconnect to paired device after it wakes from sleep

### DIFF
--- a/pwa/src/components/connection-status.ts
+++ b/pwa/src/components/connection-status.ts
@@ -113,6 +113,11 @@ export class ConnectionStatus extends LitElement {
           ${xMarkIcon('w-4 h-4')}
           Disconnected
         </div>`;
+      case ConnectionState.WAITING_FOR_DEVICE:
+        return html`<div class="badge badge-warning gap-2">
+          <span class="loading loading-spinner loading-xs"></span>
+          Waiting for device
+        </div>`;
       case ConnectionState.SCANNING:
         return html`<div class="badge badge-warning gap-2">
           <span class="loading loading-spinner loading-xs"></span>

--- a/pwa/src/components/empty-state.ts
+++ b/pwa/src/components/empty-state.ts
@@ -1,9 +1,12 @@
 import { css, html, LitElement } from 'lit';
-import { customElement } from 'lit/decorators.js';
+import { customElement, property } from 'lit/decorators.js';
 import { sharedStylesheet } from '../shared-styles';
 
 @customElement('empty-state')
 export class EmptyState extends LitElement {
+  /** Device is already paired and we're waiting for it to wake up */
+  @property({ type: Boolean }) waiting = false;
+
   static styles = [
     sharedStylesheet,
     css`
@@ -27,12 +30,29 @@ export class EmptyState extends LitElement {
   }
 
   render() {
+    if (this.waiting) {
+      return html`
+        <div class="text-center p-8">
+          <span class="loading loading-spinner loading-lg mb-4"></span>
+
+          <h1 class="text-3xl font-bold mb-4">Waiting for your device</h1>
+
+          <p class="text-base-content/70 max-w-md">
+            Your device is paired but asleep. Press the button on the device to
+            wake it &mdash; the app will reconnect automatically.
+          </p>
+        </div>
+      `;
+    }
+
     return html`
       <div class="text-center p-8">
         <h1 class="text-3xl font-bold mb-4">Connect Your Device</h1>
 
         <p class="text-base-content/70 mb-8 max-w-md">
           Connect your ESP32 LoRa device via Bluetooth to start sending and receiving messages.
+          You only need to pair once &mdash; after that the app reconnects on its own whenever the
+          device wakes up.
         </p>
 
         <button

--- a/pwa/src/components/lora-app.ts
+++ b/pwa/src/components/lora-app.ts
@@ -93,7 +93,12 @@ export class LoraApp extends LitElement {
         'warning',
         5000
       );
+      return;
     }
+
+    // Reconnect to a previously paired device without user interaction.
+    // Resolves quietly when nothing is paired yet; errors surface via onError.
+    void bleService.tryAutoReconnect();
   }
 
   disconnectedCallback() {
@@ -113,6 +118,7 @@ export class LoraApp extends LitElement {
   render() {
     const isConnected = this.connectionState === ConnectionState.CONNECTED;
     const isConnecting =
+      this.connectionState === ConnectionState.WAITING_FOR_DEVICE ||
       this.connectionState === ConnectionState.SCANNING ||
       this.connectionState === ConnectionState.CONNECTING ||
       this.connectionState === ConnectionState.DISCOVERING ||
@@ -154,6 +160,7 @@ export class LoraApp extends LitElement {
             showEmptyState
               ? html`<empty-state
                 class="h-full"
+                .waiting=${this.connectionState === ConnectionState.WAITING_FOR_DEVICE}
                 @connect-requested=${this.onConnectRequest}
               ></empty-state>`
               : html`<message-list class="h-full" .messages=${this.messages}></message-list>`
@@ -243,12 +250,12 @@ export class LoraApp extends LitElement {
 
     // Device not found or not in range
     if (message.includes('no device') || message.includes('not found')) {
-      return 'Device not found. Make sure your ESP32 is powered on and nearby, then try again.';
+      return 'Device not found. Press the button on your device to wake it, then try again.';
     }
 
     // Connection timeout
     if (message.includes('timeout') || message.includes('timed out')) {
-      return 'Connection timed out. Move closer to your device and try again.';
+      return 'Connection timed out. Press the button on your device to wake it and move closer.';
     }
 
     // Device already connected elsewhere
@@ -263,7 +270,7 @@ export class LoraApp extends LitElement {
 
     // GATT errors
     if (message.includes('gatt')) {
-      return 'Connection lost. Make sure your device is nearby and try reconnecting.';
+      return 'Connection lost. Press the button on your device to wake it and the app will reconnect.';
     }
 
     // Generic fallback with retry hint

--- a/pwa/src/components/pairing-modal.ts
+++ b/pwa/src/components/pairing-modal.ts
@@ -60,7 +60,7 @@ export class PairingModal extends LitElement {
             <div class="flex gap-3 items-start">
               <div class="badge badge-primary shrink-0">1</div>
               <div class="flex-1 text-[15px] leading-relaxed">
-                Make sure your <strong class="font-semibold">ESP32 device is powered on</strong> and within range (about 10 meters)
+                <strong class="font-semibold">Press the button on your device</strong> to wake it, and make sure it is within range (about 10 meters)
               </div>
             </div>
 
@@ -86,12 +86,23 @@ export class PairingModal extends LitElement {
             </div>
           </div>
 
-          <div class="alert alert-warning mt-6">
+          <div class="alert alert-info mt-6">
+            ${informationCircleIcon('w-5 h-5 shrink-0')}
+            <div>
+              <h3 class="font-semibold">You only have to do this once</h3>
+              <p class="text-sm mt-1">
+                After pairing, the app remembers your device. Whenever it wakes from sleep,
+                just press its button &mdash; the app reconnects on its own.
+              </p>
+            </div>
+          </div>
+
+          <div class="alert alert-warning mt-4">
             ${informationCircleIcon('w-5 h-5 shrink-0')}
             <div>
               <h3 class="font-semibold">Don't See Your Device?</h3>
               <ul class="text-sm mt-1 space-y-1 ml-5 list-disc">
-                <li>Check that your device is powered on</li>
+                <li>Press the button on your device to wake it from sleep</li>
                 <li>Move closer to your device (within 10 meters)</li>
                 <li>Try closing and reopening the pairing dialog</li>
                 <li>Make sure no other app is connected to it</li>

--- a/pwa/src/services/BleService.test.ts
+++ b/pwa/src/services/BleService.test.ts
@@ -1,0 +1,236 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { BleService, ConnectionState } from './BleService';
+
+const LAST_DEVICE_ID_KEY = 'lora.lastDeviceId';
+
+/**
+ * Minimal stand-in for a BluetoothDevice. Extends EventTarget so the service's
+ * real addEventListener/dispatchEvent wiring is exercised.
+ */
+class FakeDevice extends EventTarget {
+  gatt: { connect: () => Promise<unknown> };
+  watchAdvertisements: (options?: { signal?: AbortSignal }) => Promise<void>;
+
+  constructor(
+    public id: string,
+    public name = 'ESP32S3-LoRa',
+    connectable = true
+  ) {
+    super();
+
+    const characteristic = {
+      startNotifications: vi.fn().mockResolvedValue(undefined),
+      stopNotifications: vi.fn().mockResolvedValue(undefined),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn()
+    };
+
+    const server = {
+      connected: true,
+      disconnect: vi.fn(),
+      getPrimaryService: vi.fn().mockResolvedValue({
+        getCharacteristic: vi.fn().mockResolvedValue(characteristic)
+      })
+    };
+
+    this.gatt = {
+      connect: connectable
+        ? vi.fn().mockResolvedValue(server)
+        : vi.fn().mockRejectedValue(new Error('GATT connect failed: device unreachable'))
+    };
+
+    this.watchAdvertisements = vi.fn().mockResolvedValue(undefined);
+  }
+}
+
+/** Install a fake Web Bluetooth implementation with the given capabilities. */
+function stubBluetooth(options: {
+  devices?: FakeDevice[];
+  requestDevice?: FakeDevice;
+  persistent?: boolean;
+}) {
+  const { devices = [], requestDevice, persistent = true } = options;
+
+  const bluetooth: Record<string, unknown> = {
+    requestDevice: requestDevice
+      ? vi.fn().mockResolvedValue(requestDevice)
+      : vi.fn().mockRejectedValue(new Error('User cancelled'))
+  };
+
+  if (persistent) {
+    bluetooth.getDevices = vi.fn().mockResolvedValue(devices);
+    // supportsPersistentDevices() probes the global constructor's prototype
+    (globalThis as Record<string, unknown>).BluetoothDevice = class {
+      watchAdvertisements() {}
+    };
+  } else {
+    delete (globalThis as Record<string, unknown>).BluetoothDevice;
+  }
+
+  Object.defineProperty(navigator, 'bluetooth', {
+    value: bluetooth,
+    configurable: true,
+    writable: true
+  });
+
+  return bluetooth;
+}
+
+/** Let queued promise callbacks settle. */
+const flush = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+describe('BleService auto-reconnect', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    delete (globalThis as Record<string, unknown>).BluetoothDevice;
+  });
+
+  it('remembers the device id after a manual connect', async () => {
+    const device = new FakeDevice('device-abc');
+    stubBluetooth({ requestDevice: device });
+
+    const service = new BleService();
+    await service.connect();
+
+    expect(service.getState()).toBe(ConnectionState.CONNECTED);
+    expect(localStorage.getItem(LAST_DEVICE_ID_KEY)).toBe('device-abc');
+  });
+
+  it('offers devices matching either the service UUID or a board name prefix', async () => {
+    const device = new FakeDevice('device-abc', 'HellTecLite-LoRa-FADC');
+    const bluetooth = stubBluetooth({ requestDevice: device });
+
+    const service = new BleService();
+    await service.connect();
+
+    const options = (bluetooth.requestDevice as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    const prefixes = options.filters
+      .filter((f: { namePrefix?: string }) => f.namePrefix)
+      .map((f: { namePrefix: string }) => f.namePrefix);
+
+    expect(options.filters).toContainEqual({
+      services: ['00001234-0000-1000-8000-00805f9b34fb']
+    });
+    // Every board name embeds "LoRa"; each variant must be reachable.
+    expect(prefixes).toEqual(['HellTecLite-LoRa', 'WirelessStick-LoRa', 'nRF52-LoRa']);
+    expect(prefixes.every((p: string) => p.includes('LoRa'))).toBe(true);
+    // Name-matched devices still need access to the service.
+    expect(options.optionalServices).toContain('00001234-0000-1000-8000-00805f9b34fb');
+  });
+
+  it('reconnects to the remembered device with no user interaction', async () => {
+    const other = new FakeDevice('device-other');
+    const target = new FakeDevice('device-abc');
+    const bluetooth = stubBluetooth({ devices: [other, target] });
+    localStorage.setItem(LAST_DEVICE_ID_KEY, 'device-abc');
+
+    const service = new BleService();
+    await service.tryAutoReconnect();
+
+    expect(service.getState()).toBe(ConnectionState.CONNECTED);
+    expect(target.gatt.connect).toHaveBeenCalled();
+    expect(other.gatt.connect).not.toHaveBeenCalled();
+    // The whole point: no chooser is shown.
+    expect(bluetooth.requestDevice).not.toHaveBeenCalled();
+  });
+
+  it('falls back to the only permitted device when no id is stored', async () => {
+    const device = new FakeDevice('device-abc');
+    stubBluetooth({ devices: [device] });
+
+    const service = new BleService();
+    await service.tryAutoReconnect();
+
+    expect(service.getState()).toBe(ConnectionState.CONNECTED);
+  });
+
+  it('waits for an advertisement when the device is asleep, then reconnects on wake', async () => {
+    // Unreachable at first: this is what a deep-sleeping device looks like.
+    const device = new FakeDevice('device-abc', 'ESP32S3-LoRa', false);
+    stubBluetooth({ devices: [device] });
+
+    const service = new BleService();
+    await service.tryAutoReconnect();
+    await flush();
+
+    expect(device.watchAdvertisements).toHaveBeenCalled();
+    expect(service.getState()).toBe(ConnectionState.WAITING_FOR_DEVICE);
+
+    // The user presses the wake button; the device starts advertising again.
+    device.gatt.connect = vi.fn().mockResolvedValue({
+      connected: true,
+      disconnect: vi.fn(),
+      getPrimaryService: vi.fn().mockResolvedValue({
+        getCharacteristic: vi.fn().mockResolvedValue({
+          startNotifications: vi.fn().mockResolvedValue(undefined),
+          addEventListener: vi.fn(),
+          removeEventListener: vi.fn()
+        })
+      })
+    });
+
+    device.dispatchEvent(new Event('advertisementreceived'));
+    await flush();
+
+    expect(service.getState()).toBe(ConnectionState.CONNECTED);
+  });
+
+  it('does nothing when no device has been paired yet', async () => {
+    const bluetooth = stubBluetooth({ devices: [] });
+
+    const service = new BleService();
+    await service.tryAutoReconnect();
+
+    expect(service.getState()).toBe(ConnectionState.DISCONNECTED);
+    expect(bluetooth.requestDevice).not.toHaveBeenCalled();
+  });
+
+  it('degrades gracefully when the browser lacks persistent permissions', async () => {
+    const bluetooth = stubBluetooth({ persistent: false });
+
+    const service = new BleService();
+    await service.tryAutoReconnect();
+
+    expect(service.getState()).toBe(ConnectionState.DISCONNECTED);
+    expect(bluetooth.requestDevice).not.toHaveBeenCalled();
+    expect(bluetooth.getDevices).toBeUndefined();
+  });
+
+  it('forgets the device on explicit disconnect so it does not reconnect', async () => {
+    const device = new FakeDevice('device-abc');
+    stubBluetooth({ requestDevice: device, devices: [device] });
+
+    const service = new BleService();
+    await service.connect();
+    await service.disconnect();
+
+    expect(service.getState()).toBe(ConnectionState.DISCONNECTED);
+    expect(localStorage.getItem(LAST_DEVICE_ID_KEY)).not.toBe('device-abc');
+
+    // A subsequent auto-reconnect must not silently re-pair, even though the
+    // browser still lists the device as permitted.
+    const fresh = new BleService();
+    await fresh.tryAutoReconnect();
+    await flush();
+    expect(fresh.getState()).not.toBe(ConnectionState.CONNECTED);
+  });
+
+  it('watches for the device to return after an unexpected disconnect', async () => {
+    const device = new FakeDevice('device-abc');
+    stubBluetooth({ requestDevice: device });
+
+    const service = new BleService();
+    await service.connect();
+
+    // Firmware went to sleep and dropped the link.
+    device.dispatchEvent(new Event('gattserverdisconnected'));
+    await flush();
+
+    expect(device.watchAdvertisements).toHaveBeenCalled();
+    expect(service.getState()).toBe(ConnectionState.WAITING_FOR_DEVICE);
+  });
+});

--- a/pwa/src/services/BleService.ts
+++ b/pwa/src/services/BleService.ts
@@ -16,8 +16,39 @@ const TX_CHAR_UUID = '00005678-0000-1000-8000-00805f9b34fb'; // ESP32 → Web (n
 const RX_CHAR_UUID = '00005679-0000-1000-8000-00805f9b34fb'; // Web → ESP32 (writes)
 const INFO_CHAR_UUID = '0000567a-0000-1000-8000-00805f9b34fb'; // Device info (read-only, 16 bytes)
 
+/**
+ * Name prefixes advertised by the supported boards (BASE_DEVICE_NAME in
+ * firmware/platformio.ini); firmware appends "-<MAC suffix>", e.g.
+ * "HellTecLite-LoRa-FADC".
+ *
+ * Every board name contains "LoRa", but Web Bluetooth only matches prefixes,
+ * not substrings - so the prefixes are listed individually. These supplement
+ * the service filter: a device whose advertisement omits the service UUID
+ * (packet truncation, or a scan response the host didn't merge) is still
+ * offered in the chooser.
+ */
+const DEVICE_NAME_PREFIXES = ['HellTecLite-LoRa', 'WirelessStick-LoRa', 'nRF52-LoRa'];
+
+/**
+ * localStorage key holding the id of the last successfully paired device,
+ * so we can find it again via navigator.bluetooth.getDevices() after a reload.
+ */
+const LAST_DEVICE_ID_KEY = 'lora.lastDeviceId';
+
+/**
+ * Written to LAST_DEVICE_ID_KEY when the user disconnects on purpose.
+ *
+ * The browser keeps the pairing permission regardless, so an absent key and an
+ * opted-out user are not the same thing: absent means "never paired here" (a
+ * lone permitted device is safe to adopt), while this sentinel means "do not
+ * reconnect until asked".
+ */
+const DEVICE_OPTED_OUT = 'none';
+
 export enum ConnectionState {
   DISCONNECTED = 'DISCONNECTED',
+  /** Device is paired but asleep; waiting for it to advertise again. */
+  WAITING_FOR_DEVICE = 'WAITING_FOR_DEVICE',
   SCANNING = 'SCANNING',
   CONNECTING = 'CONNECTING',
   DISCOVERING = 'DISCOVERING',
@@ -51,8 +82,7 @@ export class BleService {
   private messageListeners = new Set<MessageListener>();
   private errorListeners = new Set<ErrorListener>();
 
-  private disconnectTimeout: number | null = null;
-  private readonly AUTO_DISCONNECT_MS = 60_000; // 60 seconds
+  private advertisementWatch: AbortController | null = null;
 
   constructor() {
     // Check Web Bluetooth support
@@ -84,12 +114,17 @@ export class BleService {
   }
 
   /**
-   * Request user to select BLE device and connect
+   * Request user to select BLE device and connect.
+   *
+   * Requires a user gesture: the browser always shows its device chooser here.
+   * Once paired, tryAutoReconnect() can reconnect without any interaction.
    */
   async connect(): Promise<void> {
     if (!this.isSupported()) {
       throw new Error('Web Bluetooth is not supported in this browser');
     }
+
+    this.stopAdvertisementWatch();
 
     // Clean up any existing connection before starting a new one
     // to prevent listener leaks if connect() is called while already connected
@@ -99,72 +134,77 @@ export class BleService {
 
     this.setState(ConnectionState.SCANNING);
 
+    let selectedDevice: BluetoothDevice;
     try {
-      // Request device with LoRa service filter
-      this.device = await navigator.bluetooth.requestDevice({
-        filters: [{ services: [SERVICE_UUID] }]
+      // Match on the service UUID or on any known board name prefix, so a
+      // device that advertises one but not the other still shows up.
+      selectedDevice = await navigator.bluetooth.requestDevice({
+        filters: [
+          { services: [SERVICE_UUID] },
+          ...DEVICE_NAME_PREFIXES.map((namePrefix) => ({ namePrefix }))
+        ],
+        // Name-matched devices still need the service to be usable.
+        optionalServices: [SERVICE_UUID]
       });
-
-      const selectedDevice = this.device;
-      if (!selectedDevice) {
-        throw new Error('No device selected');
-      }
-
-      console.log('Device selected:', selectedDevice.name);
-
-      // Listen for disconnection
-      selectedDevice.addEventListener('gattserverdisconnected', this.onDisconnected);
-
-      this.setState(ConnectionState.CONNECTING);
-
-      // Connect to GATT server
-      if (!selectedDevice.gatt) {
-        throw new Error('GATT server not available on device');
-      }
-      this.server = await selectedDevice.gatt.connect();
-      console.log('GATT server connected');
-
-      this.setState(ConnectionState.DISCOVERING);
-
-      // Discover LoRa service
-      const service = await this.server.getPrimaryService(SERVICE_UUID);
-      console.log('LoRa service discovered');
-
-      // Get characteristics
-      this.txCharacteristic = await service.getCharacteristic(TX_CHAR_UUID);
-      this.rxCharacteristic = await service.getCharacteristic(RX_CHAR_UUID);
-      console.log('Characteristics discovered');
-
-      // Get device info characteristic (optional - don't fail if not present)
-      try {
-        this.infoCharacteristic = await service.getCharacteristic(INFO_CHAR_UUID);
-        console.log('Device info characteristic discovered');
-      } catch {
-        console.log('Device info characteristic not available');
-      }
-
-      this.setState(ConnectionState.ENABLING_NOTIFICATIONS);
-
-      // Enable notifications on TX characteristic
-      await this.txCharacteristic.startNotifications();
-      this.txCharacteristic.addEventListener('characteristicvaluechanged', this.onNotification);
-      console.log('Notifications enabled');
-
-      this.setState(ConnectionState.CONNECTED);
-      this.resetDisconnectTimeout();
     } catch (error) {
-      console.error('Connection failed:', error);
+      console.error('Device selection failed:', error);
       this.setState(ConnectionState.ERROR);
       this.emitError(error as Error);
       this.cleanup();
       throw error;
     }
+
+    console.log('Device selected:', selectedDevice.name);
+    await this.connectToDevice(selectedDevice);
   }
 
   /**
-   * Disconnect from device
+   * Reconnect to a previously paired device without any user interaction.
+   *
+   * Safe to call on startup: it resolves quietly when the browser lacks
+   * persistent-permission support or when no device has been paired yet.
+   * If the device is asleep, watches for its advertisement and connects as
+   * soon as it wakes up.
+   */
+  async tryAutoReconnect(): Promise<void> {
+    if (!this.supportsPersistentDevices()) {
+      console.log('Persistent device permissions not supported; manual connect required');
+      return;
+    }
+
+    if (this.state !== ConnectionState.DISCONNECTED && this.state !== ConnectionState.ERROR) {
+      return;
+    }
+
+    const device = await this.findKnownDevice();
+    if (!device) {
+      console.log('No previously paired device available');
+      return;
+    }
+
+    console.log('Found previously paired device:', device.name);
+
+    try {
+      await this.connectToDevice(device);
+      return;
+    } catch {
+      // Device is most likely asleep - wait for it to advertise again.
+      console.log('Device not reachable, waiting for it to wake up');
+    }
+
+    this.startAdvertisementWatch(device);
+  }
+
+  /**
+   * Disconnect from device.
+   *
+   * This is an explicit user action, so it also forgets the device: otherwise
+   * the advertisement watch would immediately reconnect against their intent.
    */
   async disconnect(): Promise<void> {
+    this.stopAdvertisementWatch();
+    this.forgetDevice();
+
     if (this.server?.connected) {
       this.server.disconnect();
     }
@@ -186,7 +226,6 @@ export class BleService {
 
       // @ts-expect-error - Web Bluetooth API typing issue with Uint8Array
       await this.rxCharacteristic.writeValueWithResponse(data);
-      this.resetDisconnectTimeout();
     } catch (error) {
       console.error('Failed to send message:', error);
       this.emitError(error as Error);
@@ -218,8 +257,6 @@ export class BleService {
       const bandwidthHz = value.getUint32(10, true);
       const spreadingFactor = value.getUint8(14);
       const codingRate = value.getUint8(15);
-
-      this.resetDisconnectTimeout();
 
       return {
         batteryLevel,
@@ -263,6 +300,182 @@ export class BleService {
   }
 
   /**
+   * Private: Connect to an already-selected device and set up characteristics.
+   * Shared by the chooser path (connect) and the auto-reconnect path.
+   */
+  private async connectToDevice(device: BluetoothDevice): Promise<void> {
+    this.device = device;
+
+    try {
+      // Listen for disconnection
+      device.addEventListener('gattserverdisconnected', this.onDisconnected);
+
+      this.setState(ConnectionState.CONNECTING);
+
+      // Connect to GATT server
+      if (!device.gatt) {
+        throw new Error('GATT server not available on device');
+      }
+      this.server = await device.gatt.connect();
+      console.log('GATT server connected');
+
+      this.setState(ConnectionState.DISCOVERING);
+
+      // Discover LoRa service
+      const service = await this.server.getPrimaryService(SERVICE_UUID);
+      console.log('LoRa service discovered');
+
+      // Get characteristics
+      this.txCharacteristic = await service.getCharacteristic(TX_CHAR_UUID);
+      this.rxCharacteristic = await service.getCharacteristic(RX_CHAR_UUID);
+      console.log('Characteristics discovered');
+
+      // Get device info characteristic (optional - don't fail if not present)
+      try {
+        this.infoCharacteristic = await service.getCharacteristic(INFO_CHAR_UUID);
+        console.log('Device info characteristic discovered');
+      } catch {
+        console.log('Device info characteristic not available');
+      }
+
+      this.setState(ConnectionState.ENABLING_NOTIFICATIONS);
+
+      // Enable notifications on TX characteristic
+      await this.txCharacteristic.startNotifications();
+      this.txCharacteristic.addEventListener('characteristicvaluechanged', this.onNotification);
+      console.log('Notifications enabled');
+
+      this.rememberDevice(device);
+      this.setState(ConnectionState.CONNECTED);
+    } catch (error) {
+      console.error('Connection failed:', error);
+      this.setState(ConnectionState.ERROR);
+      this.emitError(error as Error);
+      this.cleanup();
+      throw error;
+    }
+  }
+
+  /**
+   * Private: Whether the browser exposes persistent device permissions and
+   * passive advertisement watching (Chrome's new Web Bluetooth permissions
+   * backend). Without these, only the manual chooser flow is available.
+   */
+  private supportsPersistentDevices(): boolean {
+    // @types/web-bluetooth declares BluetoothDevice as a type only, so reach
+    // for the runtime constructor through globalThis.
+    const deviceCtor = (globalThis as { BluetoothDevice?: { prototype: object } }).BluetoothDevice;
+
+    return (
+      this.isSupported() &&
+      typeof navigator.bluetooth.getDevices === 'function' &&
+      !!deviceCtor &&
+      'watchAdvertisements' in deviceCtor.prototype
+    );
+  }
+
+  /**
+   * Private: Look up a previously paired device among those this origin has
+   * permission for.
+   */
+  private async findKnownDevice(): Promise<BluetoothDevice | null> {
+    let devices: BluetoothDevice[];
+    try {
+      devices = await navigator.bluetooth.getDevices();
+    } catch (error) {
+      console.warn('Failed to list known devices:', error);
+      return null;
+    }
+
+    if (devices.length === 0) return null;
+
+    const storedId = this.readStoredDeviceId();
+
+    // The user disconnected on purpose - stay disconnected until they ask.
+    if (storedId === DEVICE_OPTED_OUT) return null;
+
+    const match = devices.find((d) => d.id === storedId);
+    if (match) return match;
+
+    // No stored id (or a stale one), but exactly one device is permitted:
+    // it can only be ours, since permission was granted via our service filter.
+    return devices.length === 1 ? devices[0] : null;
+  }
+
+  /**
+   * Private: Wait for the device to start advertising, then reconnect.
+   * Used on startup and after an unexpected disconnect, so waking the device
+   * with its button is enough to restore the session.
+   */
+  private startAdvertisementWatch(device: BluetoothDevice): void {
+    if (!this.supportsPersistentDevices()) return;
+
+    this.stopAdvertisementWatch();
+
+    const controller = new AbortController();
+    this.advertisementWatch = controller;
+
+    const onAdvertisement = () => {
+      console.log('Device is advertising again, reconnecting');
+      this.stopAdvertisementWatch();
+      this.connectToDevice(device).catch((error: unknown) => {
+        console.warn('Auto-reconnect failed, resuming watch:', error);
+        this.startAdvertisementWatch(device);
+      });
+    };
+
+    device.addEventListener('advertisementreceived', onAdvertisement, { once: true });
+    controller.signal.addEventListener('abort', () => {
+      device.removeEventListener('advertisementreceived', onAdvertisement);
+    });
+
+    device.watchAdvertisements({ signal: controller.signal }).then(
+      () => {
+        this.setState(ConnectionState.WAITING_FOR_DEVICE);
+      },
+      (error: unknown) => {
+        console.warn('Failed to watch advertisements:', error);
+        this.stopAdvertisementWatch();
+        this.setState(ConnectionState.DISCONNECTED);
+      }
+    );
+  }
+
+  /**
+   * Private: Cancel any in-flight advertisement watch
+   */
+  private stopAdvertisementWatch(): void {
+    if (this.advertisementWatch) {
+      this.advertisementWatch.abort();
+      this.advertisementWatch = null;
+    }
+  }
+
+  private rememberDevice(device: BluetoothDevice): void {
+    try {
+      localStorage.setItem(LAST_DEVICE_ID_KEY, device.id);
+    } catch (error) {
+      console.warn('Failed to remember device:', error);
+    }
+  }
+
+  private forgetDevice(): void {
+    try {
+      localStorage.setItem(LAST_DEVICE_ID_KEY, DEVICE_OPTED_OUT);
+    } catch (error) {
+      console.warn('Failed to forget device:', error);
+    }
+  }
+
+  private readStoredDeviceId(): string | null {
+    try {
+      return localStorage.getItem(LAST_DEVICE_ID_KEY);
+    } catch {
+      return null;
+    }
+  }
+
+  /**
    * Private: Handle disconnection
    */
   private onDisconnected = (): void => {
@@ -274,8 +487,16 @@ export class BleService {
       console.warn('Failed to clear messages on disconnect:', e);
     }
 
+    // Capture the handle before cleanup() clears it, so we can keep watching
+    // for the device to come back (e.g. after it wakes from deep sleep).
+    const device = this.device;
+
     this.cleanup();
     this.setState(ConnectionState.DISCONNECTED);
+
+    if (device) {
+      this.startAdvertisementWatch(device);
+    }
   };
 
   /**
@@ -295,7 +516,6 @@ export class BleService {
       console.log('Parsed message:', message);
 
       this.emitMessage(message);
-      this.resetDisconnectTimeout();
     } catch (error) {
       console.warn(
         'Failed to parse received message (possibly corrupt/truncated), ignoring:',
@@ -337,29 +557,10 @@ export class BleService {
   }
 
   /**
-   * Private: Reset auto-disconnect timeout
-   */
-  private resetDisconnectTimeout(): void {
-    if (this.disconnectTimeout !== null) {
-      window.clearTimeout(this.disconnectTimeout);
-    }
-
-    this.disconnectTimeout = window.setTimeout(() => {
-      console.log('Auto-disconnect timeout reached');
-      this.disconnect();
-    }, this.AUTO_DISCONNECT_MS);
-  }
-
-  /**
    * Private: Cleanup resources
    */
   private cleanup(): void {
     const canStopNotifications = this.server?.connected === true;
-
-    if (this.disconnectTimeout !== null) {
-      window.clearTimeout(this.disconnectTimeout);
-      this.disconnectTimeout = null;
-    }
 
     if (this.txCharacteristic) {
       try {

--- a/pwa/src/test-setup.ts
+++ b/pwa/src/test-setup.ts
@@ -1,0 +1,33 @@
+/**
+ * Vitest setup.
+ *
+ * The jsdom environment used here does not provide localStorage, so supply a
+ * minimal in-memory implementation. Real browsers always have one.
+ */
+
+if (typeof globalThis.localStorage === 'undefined') {
+  const store = new Map<string, string>();
+
+  const memoryStorage: Storage = {
+    get length() {
+      return store.size;
+    },
+    key: (index: number) => [...store.keys()][index] ?? null,
+    getItem: (key: string) => store.get(key) ?? null,
+    setItem: (key: string, value: string) => {
+      store.set(key, String(value));
+    },
+    removeItem: (key: string) => {
+      store.delete(key);
+    },
+    clear: () => {
+      store.clear();
+    }
+  };
+
+  Object.defineProperty(globalThis, 'localStorage', {
+    value: memoryStorage,
+    configurable: true,
+    writable: true
+  });
+}

--- a/pwa/src/test-setup.ts
+++ b/pwa/src/test-setup.ts
@@ -3,9 +3,16 @@
  *
  * The jsdom environment used here does not provide localStorage, so supply a
  * minimal in-memory implementation. Real browsers always have one.
+ *
+ * Node also exposes a built-in localStorage that is inert unless started with
+ * --localstorage-file, and whether it exists at all varies by version: absent
+ * on Node 26, present but unusable on Node 25 (which CI runs). So feature-test
+ * an actual method instead of the binding, and always install over a stub.
  */
 
-if (typeof globalThis.localStorage === 'undefined') {
+const existing = globalThis.localStorage as Storage | undefined;
+
+if (typeof existing?.clear !== 'function' || typeof existing?.getItem !== 'function') {
   const store = new Map<string, string>();
 
   const memoryStorage: Storage = {

--- a/pwa/vitest.config.ts
+++ b/pwa/vitest.config.ts
@@ -4,6 +4,11 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
   test: {
     environment: 'jsdom', // or 'happy-dom'
-    globals: true
+    globals: true,
+    // A concrete origin is required for storage APIs to be available
+    environmentOptions: {
+      jsdom: { url: 'http://localhost/' }
+    },
+    setupFiles: ['./src/test-setup.ts']
   }
 });


### PR DESCRIPTION
Reconnecting required two manual steps: press the wake button on the device, then press Connect and pick the device out of the OS chooser again. requestDevice() always requires a fresh user gesture and always shows the chooser, so the app never remembered the device.

Remember the paired device and reconnect without interaction:

- getDevices() finds the previously paired device (permission persists across reloads), and watchAdvertisements() connects as soon as the device advertises again. Pressing the wake button is now enough.
- Extract connectToDevice() so the chooser path and the auto-reconnect path share one implementation.
- Re-arm the advertisement watch on unexpected disconnect, so a sleep-induced drop self-heals.
- Drop the 60s app-side auto-disconnect; the firmware owns sleep policy and a second timeout only added another way to lose the link.
- Explicit disconnect records an opt-out sentinel. The browser keeps the pairing permission regardless, so "never paired" and "user said no" must be distinguishable or Disconnect would immediately reconnect.
- Also match the chooser on board name prefixes (HellTecLite-LoRa, WirelessStick-LoRa, nRF52-LoRa) alongside the service UUID, so a device whose advertisement omits the service still appears.

Both APIs need Chrome's new Web Bluetooth permissions backend, so they are feature-detected and fall back to the existing chooser flow.

Add a new WAITING_FOR_DEVICE state surfaced as a status badge and an empty state telling the user to press the wake button.

Tests need a DOM and a concrete origin; this jsdom provides no localStorage, hence the setup shim.