### PR TITLE
fix(pwa): reconnect without flag-gated Web Bluetooth APIs

### DIFF
--- a/pwa/src/services/BleService.test.ts
+++ b/pwa/src/services/BleService.test.ts
@@ -3,6 +3,24 @@ import { BleService, ConnectionState } from './BleService';
 
 const LAST_DEVICE_ID_KEY = 'lora.lastDeviceId';
 
+/** A GATT server exposing the service and characteristics BleService expects. */
+function makeServer() {
+  const characteristic = {
+    startNotifications: vi.fn().mockResolvedValue(undefined),
+    stopNotifications: vi.fn().mockResolvedValue(undefined),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn()
+  };
+
+  return {
+    connected: true,
+    disconnect: vi.fn(),
+    getPrimaryService: vi.fn().mockResolvedValue({
+      getCharacteristic: vi.fn().mockResolvedValue(characteristic)
+    })
+  };
+}
+
 /**
  * Minimal stand-in for a BluetoothDevice. Extends EventTarget so the service's
  * real addEventListener/dispatchEvent wiring is exercised.
@@ -18,24 +36,9 @@ class FakeDevice extends EventTarget {
   ) {
     super();
 
-    const characteristic = {
-      startNotifications: vi.fn().mockResolvedValue(undefined),
-      stopNotifications: vi.fn().mockResolvedValue(undefined),
-      addEventListener: vi.fn(),
-      removeEventListener: vi.fn()
-    };
-
-    const server = {
-      connected: true,
-      disconnect: vi.fn(),
-      getPrimaryService: vi.fn().mockResolvedValue({
-        getCharacteristic: vi.fn().mockResolvedValue(characteristic)
-      })
-    };
-
     this.gatt = {
       connect: connectable
-        ? vi.fn().mockResolvedValue(server)
+        ? vi.fn().mockResolvedValue(makeServer())
         : vi.fn().mockRejectedValue(new Error('GATT connect failed: device unreachable'))
     };
 
@@ -161,17 +164,7 @@ describe('BleService auto-reconnect', () => {
     expect(service.getState()).toBe(ConnectionState.WAITING_FOR_DEVICE);
 
     // The user presses the wake button; the device starts advertising again.
-    device.gatt.connect = vi.fn().mockResolvedValue({
-      connected: true,
-      disconnect: vi.fn(),
-      getPrimaryService: vi.fn().mockResolvedValue({
-        getCharacteristic: vi.fn().mockResolvedValue({
-          startNotifications: vi.fn().mockResolvedValue(undefined),
-          addEventListener: vi.fn(),
-          removeEventListener: vi.fn()
-        })
-      })
-    });
+    device.gatt.connect = vi.fn().mockResolvedValue(makeServer());
 
     device.dispatchEvent(new Event('advertisementreceived'));
     await flush();
@@ -217,6 +210,70 @@ describe('BleService auto-reconnect', () => {
     await fresh.tryAutoReconnect();
     await flush();
     expect(fresh.getState()).not.toBe(ConnectionState.CONNECTED);
+  });
+
+  it('polls to reconnect when watchAdvertisements is unavailable', async () => {
+    // Today's Chrome for Android: neither flag enabled. gatt.connect() still
+    // works on a handle we already hold, so a wake must still be picked up.
+    vi.useFakeTimers();
+    try {
+      const device = new FakeDevice('device-abc');
+      stubBluetooth({ requestDevice: device });
+      delete (globalThis as Record<string, unknown>).BluetoothDevice;
+
+      const service = new BleService();
+      await service.connect();
+      expect(service.getState()).toBe(ConnectionState.CONNECTED);
+
+      // Device sleeps and drops the link, and is unreachable while asleep.
+      device.gatt.connect = vi.fn().mockRejectedValue(new Error('unreachable'));
+      device.dispatchEvent(new Event('gattserverdisconnected'));
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(service.getState()).toBe(ConnectionState.WAITING_FOR_DEVICE);
+
+      // A couple of failed attempts while it is still asleep.
+      await vi.advanceTimersByTimeAsync(7000);
+      expect(device.gatt.connect).toHaveBeenCalled();
+      expect(service.getState()).toBe(ConnectionState.WAITING_FOR_DEVICE);
+
+      // User presses the wake button.
+      device.gatt.connect = vi.fn().mockResolvedValue(makeServer());
+      await vi.advanceTimersByTimeAsync(3500);
+
+      expect(service.getState()).toBe(ConnectionState.CONNECTED);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('stops polling when the user disconnects on purpose', async () => {
+    vi.useFakeTimers();
+    try {
+      const device = new FakeDevice('device-abc');
+      stubBluetooth({ requestDevice: device });
+      delete (globalThis as Record<string, unknown>).BluetoothDevice;
+
+      const service = new BleService();
+      await service.connect();
+
+      device.gatt.connect = vi.fn().mockRejectedValue(new Error('unreachable'));
+      device.dispatchEvent(new Event('gattserverdisconnected'));
+      await vi.advanceTimersByTimeAsync(0);
+      expect(service.getState()).toBe(ConnectionState.WAITING_FOR_DEVICE);
+
+      await service.disconnect();
+      const callsAtDisconnect = (device.gatt.connect as ReturnType<typeof vi.fn>).mock.calls.length;
+
+      // Polling must not resume behind the user's back.
+      await vi.advanceTimersByTimeAsync(30_000);
+      expect((device.gatt.connect as ReturnType<typeof vi.fn>).mock.calls.length).toBe(
+        callsAtDisconnect
+      );
+      expect(service.getState()).toBe(ConnectionState.DISCONNECTED);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('watches for the device to return even when getDevices() is unavailable', async () => {

--- a/pwa/src/services/BleService.ts
+++ b/pwa/src/services/BleService.ts
@@ -45,6 +45,16 @@ const LAST_DEVICE_ID_KEY = 'lora.lastDeviceId';
  */
 const DEVICE_OPTED_OUT = 'none';
 
+/**
+ * Polling cadence for the no-watchAdvertisements fallback.
+ *
+ * 3s keeps the wake feeling responsive without hammering the radio; 100
+ * attempts is ~5 minutes, long enough to cover someone walking back to the
+ * device but short of polling all night.
+ */
+const RECONNECT_INTERVAL_MS = 3_000;
+const RECONNECT_MAX_ATTEMPTS = 100;
+
 export enum ConnectionState {
   DISCONNECTED = 'DISCONNECTED',
   /** Device is paired but asleep; waiting for it to advertise again. */
@@ -83,6 +93,7 @@ export class BleService {
   private errorListeners = new Set<ErrorListener>();
 
   private advertisementWatch: AbortController | null = null;
+  private reconnectTimer: number | null = null;
 
   constructor() {
     // Check Web Bluetooth support
@@ -139,7 +150,7 @@ export class BleService {
       throw new Error('Web Bluetooth is not supported in this browser');
     }
 
-    this.stopAdvertisementWatch();
+    this.stopAutoReconnect();
 
     // Clean up any existing connection before starting a new one
     // to prevent listener leaks if connect() is called while already connected
@@ -218,11 +229,11 @@ export class BleService {
   /**
    * Disconnect from device.
    *
-   * This is an explicit user action, so it also forgets the device: otherwise
-   * the advertisement watch would immediately reconnect against their intent.
+   * This is an explicit user action, so it also forgets the device and stops
+   * all automatic reconnection: otherwise we would reconnect against intent.
    */
   async disconnect(): Promise<void> {
-    this.stopAdvertisementWatch();
+    this.stopAutoReconnect();
     this.forgetDevice();
 
     if (this.server?.connected) {
@@ -435,7 +446,10 @@ export class BleService {
    */
   private startAdvertisementWatch(device: BluetoothDevice): void {
     if (!this.supportsAdvertisementWatch()) {
-      console.log('watchAdvertisements not available; manual reconnect required');
+      // watchAdvertisements is flag-gated in Chrome. Until it ships, poll the
+      // handle instead: gatt.connect() needs no flag and succeeds as soon as
+      // the device is awake, which is the same outcome a little less promptly.
+      this.startReconnectPolling(device);
       return;
     }
 
@@ -468,6 +482,59 @@ export class BleService {
         this.setState(ConnectionState.DISCONNECTED);
       }
     );
+  }
+
+  /**
+   * Private: Retry gatt.connect() until the device wakes up.
+   *
+   * Fallback for browsers without watchAdvertisements. Only works while the
+   * page holds the device handle - a reload loses it and needs getDevices(),
+   * which is flag-gated too. Gives up after RECONNECT_MAX_ATTEMPTS so a device
+   * that is off for the night does not poll the radio forever.
+   */
+  private startReconnectPolling(device: BluetoothDevice, attempt = 0): void {
+    this.stopReconnectPolling();
+
+    if (attempt >= RECONNECT_MAX_ATTEMPTS) {
+      console.log('Gave up waiting for device to wake up');
+      this.setState(ConnectionState.DISCONNECTED);
+      return;
+    }
+
+    this.setState(ConnectionState.WAITING_FOR_DEVICE);
+
+    this.reconnectTimer = window.setTimeout(() => {
+      // A manual connect may have landed while this was pending.
+      if (this.isConnected()) return;
+
+      this.connectToDevice(device)
+        .then(() => {
+          console.log('Reconnected after device woke up');
+        })
+        .catch(() => {
+          this.startReconnectPolling(device, attempt + 1);
+        });
+    }, RECONNECT_INTERVAL_MS);
+  }
+
+  /**
+   * Private: Cancel any pending reconnect attempt
+   */
+  private stopReconnectPolling(): void {
+    if (this.reconnectTimer !== null) {
+      window.clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = null;
+    }
+  }
+
+  /**
+   * Private: Stop all automatic reconnection, whichever mechanism is in use.
+   * Call before any user-initiated connect or disconnect so the automation
+   * never races the user.
+   */
+  private stopAutoReconnect(): void {
+    this.stopAdvertisementWatch();
+    this.stopReconnectPolling();
   }
 
   /**


### PR DESCRIPTION
Auto-reconnect relied on watchAdvertisements(), which is flag-gated in Chrome. On a stock Chrome for Android both it and getDevices() report false, so waking the device did nothing and the app sat disconnected until the user pressed Connect again.

Fall back to retrying gatt.connect() on the device handle we already hold. That needs no flag and succeeds as soon as the device wakes, giving the same zero-tap result slightly less promptly. watchAdvertisements is still preferred when present, so this improves automatically as the API ships.

Poll every 3s for at most 100 attempts (~5 min) so a device left off does not keep the radio busy. The fallback only survives while the page holds the handle; restoring a pairing across a reload still needs getDevices().

Consolidate cancellation into stopAutoReconnect() so a user-initiated connect or disconnect always stops both mechanisms.